### PR TITLE
feat: add the possibility to restrict service user to specific zones

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -17,12 +17,9 @@ data "aws_iam_policy_document" "external_dns" {
 
     actions = [
       "route53:ChangeResourceRecordSets",
-      "route53:ListTagsForResource"
     ]
 
-    resources = [
-      "arn:aws:route53:::hostedzone/*",
-    ]
+    resources = [ for id in var.policy_allowed_zone_ids: "arn:aws:route53:::hostedzone/${id}"]
 
     effect = "Allow"
   }
@@ -33,6 +30,7 @@ data "aws_iam_policy_document" "external_dns" {
     actions = [
       "route53:ListHostedZones",
       "route53:ListResourceRecordSets",
+      "route53:ListTagsForResource",
     ]
 
     resources = [

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "cluster_name" {}
 variable "cluster_identity_oidc_issuer" {}
 variable "cluster_identity_oidc_issuer_arn" {}
 
+variable "policy_allowed_zone_ids" {
+  type = list(string)
+  default = ["*"]
+}
+
 # external-dns
 variable "enabled" {
   type = bool


### PR DESCRIPTION
This restricts updates to the provided zone ids so nothing bad can happen with other zones.