### PR TITLE
Override or add configuration options in values input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  TERRAFORM_DOCS_VERSION: "v0.11.2"
+  TERRAFORM_DOCS_VERSION: "v0.15.0"
   TFLINT_VERSION: "v0.25.0"
   TFSEC_VERSION: "v0.39.6"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
 #    - id: terraform_tfsec
     - id: terraform_docs
       args:
-        - '--args=--hide providers --sort-by-required'
+        - '--args=--hide providers --sort-by required'
 
   - repo: git://github.com/pecigonzalo/pre-commit-terraform-vars
     rev: v1.0.0

--- a/README.md
+++ b/README.md
@@ -67,15 +67,18 @@ No modules.
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"external-dns"` | no |
-| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"5.4.4"` | no |
+| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"9.10.3"` | no |
+| <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Create the namespace if it does not yet exist | `bool` | `true` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"external-dns"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://charts.bitnami.com/bitnami"` | no |
-| <a name="input_k8s_create_namespace"></a> [k8s\_create\_namespace](#input\_k8s\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `true` | no |
-| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The k8s namespace in which the external-dns service account has been created | `string` | `"kube-system"` | no |
-| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s external-dns service account name | `string` | `"external-dns"` | no |
+| <a name="input_k8s_irsa_role_create"></a> [k8s\_irsa\_role\_create](#input\_k8s\_irsa\_role\_create) | Whether to create IRSA role and annotate service account | `bool` | `true` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the node-problem-detector service account has been created | `string` | `"cluster-autoscaler"` | no |
+| <a name="input_k8s_rbac_create"></a> [k8s\_rbac\_create](#input\_k8s\_rbac\_create) | Whether to create and use RBAC resources | `bool` | `true` | no |
+| <a name="input_k8s_service_account_create"></a> [k8s\_service\_account\_create](#input\_k8s\_service\_account\_create) | Whether to create Service Account | `bool` | `true` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s cluster-autoscaler service account name | `string` | `"cluster-autoscaler"` | no |
 | <a name="input_policy_allowed_zone_ids"></a> [policy\_allowed\_zone\_ids](#input\_policy\_allowed\_zone\_ids) | List of the Route53 zone ids for service account IAM role access | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
-| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/bitnami/external-dns | `map(any)` | `{}` | no |
-| <a name="input_values"></a> [values](#input\_values) | Additional values for helm chart. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
+| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `map(any)` | `{}` | no |
+| <a name="input_values"></a> [values](#input\_values) | Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `string` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ No modules.
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"external-dns"` | no |
 | <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"5.4.4"` | no |
-| <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Create the namespace if it does not yet exist | `bool` | `true` | no |
+| <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `true` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"external-dns"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://charts.bitnami.com/bitnami"` | no |
 | <a name="input_k8s_irsa_role_create"></a> [k8s\_irsa\_role\_create](#input\_k8s\_irsa\_role\_create) | Whether to create IRSA role and annotate service account | `bool` | `true` | no |
-| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the node-problem-detector service account has been created | `string` | `"kube-system"` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the external-dns will be installed | `string` | `"kube-system"` | no |
 | <a name="input_k8s_rbac_create"></a> [k8s\_rbac\_create](#input\_k8s\_rbac\_create) | Whether to create and use RBAC resources | `bool` | `true` | no |
 | <a name="input_k8s_service_account_create"></a> [k8s\_service\_account\_create](#input\_k8s\_service\_account\_create) | Whether to create Service Account | `bool` | `true` | no |
 | <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s external-dns service account name | `string` | `"external-dns"` | no |

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ No modules.
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"external-dns"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://charts.bitnami.com/bitnami"` | no |
 | <a name="input_k8s_irsa_role_create"></a> [k8s\_irsa\_role\_create](#input\_k8s\_irsa\_role\_create) | Whether to create IRSA role and annotate service account | `bool` | `true` | no |
-| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the node-problem-detector service account has been created | `string` | `"cluster-autoscaler"` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the node-problem-detector service account has been created | `string` | `"external-dns"` | no |
 | <a name="input_k8s_rbac_create"></a> [k8s\_rbac\_create](#input\_k8s\_rbac\_create) | Whether to create and use RBAC resources | `bool` | `true` | no |
 | <a name="input_k8s_service_account_create"></a> [k8s\_service\_account\_create](#input\_k8s\_service\_account\_create) | Whether to create Service Account | `bool` | `true` | no |
-| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s cluster-autoscaler service account name | `string` | `"cluster-autoscaler"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s external-dns service account name | `string` | `"external-dns"` | no |
 | <a name="input_policy_allowed_zone_ids"></a> [policy\_allowed\_zone\_ids](#input\_policy\_allowed\_zone\_ids) | List of the Route53 zone ids for service account IAM role access | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
-| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `map(any)` | `{}` | no |
-| <a name="input_values"></a> [values](#input\_values) | Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `string` | `""` | no |
+| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/external-dns | `map(any)` | `{}` | no |
+| <a name="input_values"></a> [values](#input\_values) | Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/external-dns | `string` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ No modules.
 | <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `true` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"external-dns"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://charts.bitnami.com/bitnami"` | no |
+| <a name="input_k8s_assume_role_arn"></a> [k8s\_assume\_role\_arn](#input\_k8s\_assume\_role\_arn) | Whether to create and use default role or assume existing role. Useful for hosted zones in another AWS account. Default (empty string) use default role. | `string` | `""` | no |
 | <a name="input_k8s_irsa_role_create"></a> [k8s\_irsa\_role\_create](#input\_k8s\_irsa\_role\_create) | Whether to create IRSA role and annotate service account | `bool` | `true` | no |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the external-dns will be installed | `string` | `"kube-system"` | no |
 | <a name="input_k8s_rbac_create"></a> [k8s\_rbac\_create](#input\_k8s\_rbac\_create) | Whether to create and use RBAC resources | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ No modules.
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"external-dns"` | no |
-| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"9.10.3"` | no |
+| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"5.4.4"` | no |
 | <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Create the namespace if it does not yet exist | `bool` | `true` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"external-dns"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://charts.bitnami.com/bitnami"` | no |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ No modules.
 | [aws_iam_role.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.external_dns](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubernetes_namespace.external_dns](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [aws_iam_policy_document.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.external_dns_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.external_dns_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/README.md
+++ b/README.md
@@ -35,51 +35,52 @@ See [Basic example](examples/basic/README.md) for further information.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 2.0 |
-| helm | >= 1.0 |
-| kubernetes | >= 1.10 |
-| local | >= 1.3 |
-| null | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1.0 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.12.0 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
-| [helm_release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) |
-| [kubernetes_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) |
+| Name | Type |
+|------|------|
+| [aws_iam_policy.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [helm_release.external_dns](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_namespace.external_dns](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [aws_iam_policy_document.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.external_dns_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.external_dns_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cluster\_identity\_oidc\_issuer | The OIDC Identity issuer for the cluster | `string` | n/a | yes |
-| cluster\_identity\_oidc\_issuer\_arn | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account | `string` | n/a | yes |
-| cluster\_name | The name of the cluster | `string` | n/a | yes |
-| enabled | Variable indicating whether deployment is enabled | `bool` | `true` | no |
-| helm\_chart\_name | Helm chart name to be installed | `string` | `"external-dns"` | no |
-| helm\_chart\_version | Version of the Helm chart | `string` | `"4.9.0"` | no |
-| helm\_release\_name | Helm release name | `string` | `"external-dns"` | no |
-| helm\_repo\_url | Helm repository | `string` | `"https://charts.bitnami.com/bitnami"` | no |
-| k8s\_create\_namespace | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `true` | no |
-| k8s\_namespace | The k8s namespace in which the external-dns service account has been created | `string` | `"kube-system"` | no |
-| k8s\_service\_account\_name | The k8s external-dns service account name | `string` | `"external-dns"` | no |
-| mod\_dependency | Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable | `any` | `null` | no |
-| policy\_allowed\_zone\_ids | List of the Route53 zone ids for service account IAM role access | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
-| settings | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/bitnami/external-dns | `map(any)` | `{}` | no |
+| <a name="input_cluster_identity_oidc_issuer"></a> [cluster\_identity\_oidc\_issuer](#input\_cluster\_identity\_oidc\_issuer) | The OIDC Identity issuer for the cluster | `string` | n/a | yes |
+| <a name="input_cluster_identity_oidc_issuer_arn"></a> [cluster\_identity\_oidc\_issuer\_arn](#input\_cluster\_identity\_oidc\_issuer\_arn) | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | n/a | yes |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
+| <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"external-dns"` | no |
+| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"5.4.4"` | no |
+| <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"external-dns"` | no |
+| <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://charts.bitnami.com/bitnami"` | no |
+| <a name="input_k8s_create_namespace"></a> [k8s\_create\_namespace](#input\_k8s\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `true` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The k8s namespace in which the external-dns service account has been created | `string` | `"kube-system"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s external-dns service account name | `string` | `"external-dns"` | no |
+| <a name="input_policy_allowed_zone_ids"></a> [policy\_allowed\_zone\_ids](#input\_policy\_allowed\_zone\_ids) | List of the Route53 zone ids for service account IAM role access | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/bitnami/external-dns | `map(any)` | `{}` | no |
+| <a name="input_values"></a> [values](#input\_values) | Additional values for helm chart. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
 
 ## Outputs
 
-No output.
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Contributing and reporting issues

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ No modules.
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"external-dns"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://charts.bitnami.com/bitnami"` | no |
 | <a name="input_k8s_irsa_role_create"></a> [k8s\_irsa\_role\_create](#input\_k8s\_irsa\_role\_create) | Whether to create IRSA role and annotate service account | `bool` | `true` | no |
-| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the node-problem-detector service account has been created | `string` | `"external-dns"` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the node-problem-detector service account has been created | `string` | `"kube-system"` | no |
 | <a name="input_k8s_rbac_create"></a> [k8s\_rbac\_create](#input\_k8s\_rbac\_create) | Whether to create and use RBAC resources | `bool` | `true` | no |
 | <a name="input_k8s_service_account_create"></a> [k8s\_service\_account\_create](#input\_k8s\_service\_account\_create) | Whether to create Service Account | `bool` | `true` | no |
 | <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s external-dns service account name | `string` | `"external-dns"` | no |
 | <a name="input_policy_allowed_zone_ids"></a> [policy\_allowed\_zone\_ids](#input\_policy\_allowed\_zone\_ids) | List of the Route53 zone ids for service account IAM role access | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
-| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/external-dns | `map(any)` | `{}` | no |
-| <a name="input_values"></a> [values](#input\_values) | Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/external-dns | `string` | `""` | no |
+| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/bitnami/external-dns | `map(any)` | `{}` | no |
+| <a name="input_values"></a> [values](#input\_values) | Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/bitnami/external-dns | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,23 +11,23 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| eks_cluster | cloudposse/eks-cluster/aws |  |
-| eks_workers | cloudposse/eks-workers/aws |  |
-| extenral_dns | ../../ |  |
-| vpc | terraform-aws-modules/vpc/aws |  |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | n/a |
+| <a name="module_eks_workers"></a> [eks\_workers](#module\_eks\_workers) | cloudposse/eks-workers/aws | n/a |
+| <a name="module_extenral_dns"></a> [extenral\_dns](#module\_extenral\_dns) | ../../ | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) |
-| [aws_eks_cluster_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) |
+| Name | Type |
+|------|------|
+| [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
-No output.
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,10 +11,10 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | n/a |
-| <a name="module_eks_workers"></a> [eks\_workers](#module\_eks\_workers) | cloudposse/eks-workers/aws | n/a |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 0.43.2 |
+| <a name="module_eks_node_group"></a> [eks\_node\_group](#module\_eks\_node\_group) | cloudposse/eks-node-group/aws | 0.25.0 |
 | <a name="module_extenral_dns"></a> [extenral\_dns](#module\_extenral\_dns) | ../../ | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.6.0 |
 
 ## Resources
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
 
-  name               = "cluster-autoscaler-vpc"
+  name               = "external-dns-vpc"
   cidr               = "10.0.0.0/16"
   azs                = ["eu-central-1a", "eu-central-1b"]
   public_subnets     = ["10.0.101.0/24", "10.0.102.0/24"]
@@ -14,7 +14,7 @@ module "eks_cluster" {
   region     = "eu-central-1"
   subnet_ids = module.vpc.public_subnets
   vpc_id     = module.vpc.vpc_id
-  name       = "cluster-autoscaler"
+  name       = "external-dns"
 
   workers_security_group_ids = [module.eks_workers.security_group_id]
   workers_role_arns          = [module.eks_workers.workers_role_arn]
@@ -25,8 +25,7 @@ module "eks_workers" {
 
   cluster_certificate_authority_data = module.eks_cluster.eks_cluster_certificate_authority_data
   cluster_endpoint                   = module.eks_cluster.eks_cluster_endpoint
-  cluster_name                       = module.eks_cluster.eks_cluster_id
-  cluster_security_group_id          = module.eks_cluster.security_group_id
+  cluster_name                       = "external-dns"
   instance_type                      = "t3.medium"
   max_size                           = 1
   min_size                           = 1

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,5 +1,6 @@
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.6.0"
 
   name               = "external-dns-vpc"
   cidr               = "10.0.0.0/16"
@@ -9,33 +10,27 @@ module "vpc" {
 }
 
 module "eks_cluster" {
-  source = "cloudposse/eks-cluster/aws"
+  source  = "cloudposse/eks-cluster/aws"
+  version = "0.43.2"
 
   region     = "eu-central-1"
   subnet_ids = module.vpc.public_subnets
   vpc_id     = module.vpc.vpc_id
   name       = "external-dns"
-
-  workers_security_group_ids = [module.eks_workers.security_group_id]
-  workers_role_arns          = [module.eks_workers.workers_role_arn]
 }
 
-module "eks_workers" {
-  source = "cloudposse/eks-workers/aws"
+module "eks_node_group" {
+  source  = "cloudposse/eks-node-group/aws"
+  version = "0.25.0"
 
-  cluster_certificate_authority_data = module.eks_cluster.eks_cluster_certificate_authority_data
-  cluster_endpoint                   = module.eks_cluster.eks_cluster_endpoint
-  cluster_name                       = "external-dns"
-  instance_type                      = "t3.medium"
-  max_size                           = 1
-  min_size                           = 1
-  subnet_ids                         = module.vpc.public_subnets
-  vpc_id                             = module.vpc.vpc_id
-
-  associate_public_ip_address = true
+  cluster_name   = "external-dns"
+  instance_types = ["t3.medium"]
+  subnet_ids     = module.vpc.public_subnets
+  min_size       = 1
+  desired_size   = 1
+  max_size       = 2
+  depends_on     = [module.eks_cluster.kubernetes_config_map_id]
 }
-
-# Use the module:
 
 module "extenral_dns" {
   source = "../../"

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 locals {
-  assume_role = length(try(var.settings["aws.assumeRoleArn"], "")) > 0 ? true : false
+  assume_role = length(var.k8s_assume_role_arn) > 0 ? true : false
 }
 
 data "aws_iam_policy_document" "external_dns" {
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "external_dns_assume" {
     ]
 
     resources = [
-      var.settings["aws.assumeRoleArn"]
+      var.k8s_assume_role_arn
     ]
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -4,14 +4,6 @@ locals {
   assume_role = length(try(var.settings["aws.assumeRoleArn"], "")) > 0 ? true : false
 }
 
-resource "kubernetes_namespace" "external_dns" {
-  count = (var.enabled && var.k8s_create_namespace && var.k8s_namespace != "kube-system") ? 1 : 0
-
-  metadata {
-    name = var.k8s_namespace
-  }
-}
-
 ### iam ###
 # Policy
 data "aws_iam_policy_document" "external_dns" {

--- a/iam.tf
+++ b/iam.tf
@@ -5,8 +5,7 @@ locals {
 }
 
 resource "kubernetes_namespace" "external_dns" {
-  depends_on = [var.mod_dependency]
-  count      = (var.enabled && var.k8s_create_namespace && var.k8s_namespace != "kube-system") ? 1 : 0
+  count = (var.enabled && var.k8s_create_namespace && var.k8s_namespace != "kube-system") ? 1 : 0
 
   metadata {
     name = var.k8s_namespace
@@ -74,8 +73,6 @@ resource "aws_iam_policy" "external_dns" {
   description = "Policy for external-dns service"
 
   policy = local.assume_role ? data.aws_iam_policy_document.external_dns_assume[0].json : data.aws_iam_policy_document.external_dns[0].json
-
-  depends_on = [var.mod_dependency]
 }
 
 # Role
@@ -108,8 +105,6 @@ resource "aws_iam_role" "external_dns" {
 
   name               = "${var.cluster_name}-external-dns"
   assume_role_policy = data.aws_iam_policy_document.external_dns_irsa[0].json
-
-  depends_on = [var.mod_dependency]
 }
 
 resource "aws_iam_role_policy_attachment" "external_dns" {
@@ -118,5 +113,4 @@ resource "aws_iam_role_policy_attachment" "external_dns" {
   role       = aws_iam_role.external_dns[0].name
   policy_arn = aws_iam_policy.external_dns[0].arn
 
-  depends_on = [var.mod_dependency]
 }

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ locals {
   values = yamlencode({
     "aws" : {
       "region" : data.aws_region.current.name
+      "assumeRoleArn" : var.k8s_assume_role_arn
     }
     "rbac" : {
       "create" : var.k8s_rbac_create

--- a/main.tf
+++ b/main.tf
@@ -1,38 +1,43 @@
+locals {
+  values = yamlencode({
+    "aws" : {
+      "region" : data.aws_region.current.name
+    }
+    "rbac" : {
+      "create" : true
+    }
+    "serviceAccount" : {
+      "create" : true
+      "name" : var.k8s_service_account_name
+      "annotations" : {
+        "eks.amazonaws.com/role-arn" : aws_iam_role.external_dns[0].arn
+      }
+    }
+  })
+}
+
+data "utils_deep_merge_yaml" "values" {
+  count = var.enabled ? 1 : 0
+  input = compact([
+    local.values,
+    var.values
+  ])
+}
+
 data "aws_region" "current" {}
 
 resource "helm_release" "external_dns" {
-  depends_on = [var.mod_dependency]
-  count      = var.enabled ? 1 : 0
-  chart      = var.helm_chart_name
-  namespace  = var.k8s_namespace
-  name       = var.helm_release_name
-  version    = var.helm_chart_version
-  repository = var.helm_repo_url
+  count            = var.enabled ? 1 : 0
+  chart            = var.helm_chart_name
+  create_namespace = var.k8s_create_namespace
+  namespace        = var.k8s_namespace
+  name             = var.helm_release_name
+  version          = var.helm_chart_version
+  repository       = var.helm_repo_url
 
-  set {
-    name  = "aws.region"
-    value = data.aws_region.current.name
-  }
-
-  set {
-    name  = "rbac.create"
-    value = "true"
-  }
-
-  set {
-    name  = "serviceAccount.create"
-    value = "true"
-  }
-
-  set {
-    name  = "serviceAccount.name"
-    value = var.k8s_service_account_name
-  }
-
-  set {
-    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
-    value = aws_iam_role.external_dns[0].arn
-  }
+  values = [
+    data.utils_deep_merge_yaml.values[0].output
+  ]
 
   dynamic "set" {
     for_each = var.settings

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "helm_repo_url" {
 variable "helm_create_namespace" {
   type        = bool
   default     = true
-  description = "Whether to create k8s namespace with name defined by `k8s_namespace"
+  description = "Whether to create k8s namespace with name defined by `k8s_namespace`"
 }
 
 variable "k8s_namespace" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,8 @@
-# Required module inputs
+variable "enabled" {
+  type        = bool
+  default     = true
+  description = "Variable indicating whether deployment is enabled"
+}
 
 variable "cluster_name" {
   type        = string
@@ -15,23 +19,6 @@ variable "cluster_identity_oidc_issuer_arn" {
   description = "The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account"
 }
 
-variable "policy_allowed_zone_ids" {
-  type        = list(string)
-  default     = ["*"]
-  description = "List of the Route53 zone ids for service account IAM role access"
-}
-
-# external-dns
-
-variable "enabled" {
-  type        = bool
-  default     = true
-  description = "Variable indicating whether deployment is enabled"
-
-}
-
-# Helm
-
 variable "helm_chart_name" {
   type        = string
   default     = "external-dns"
@@ -40,7 +27,7 @@ variable "helm_chart_name" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "5.4.4"
+  default     = "9.10.3"
   description = "Version of the Helm chart"
 }
 
@@ -49,41 +36,61 @@ variable "helm_release_name" {
   default     = "external-dns"
   description = "Helm release name"
 }
-
 variable "helm_repo_url" {
   type        = string
   default     = "https://charts.bitnami.com/bitnami"
   description = "Helm repository"
 }
 
-# K8S
-
-variable "k8s_create_namespace" {
+variable "helm_create_namespace" {
   type        = bool
   default     = true
-  description = "Whether to create k8s namespace with name defined by `k8s_namespace`"
+  description = "Create the namespace if it does not yet exist"
 }
 
 variable "k8s_namespace" {
   type        = string
-  default     = "kube-system"
-  description = "The k8s namespace in which the external-dns service account has been created"
+  default     = "cluster-autoscaler"
+  description = "The K8s namespace in which the node-problem-detector service account has been created"
+}
+
+variable "k8s_rbac_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create and use RBAC resources"
+}
+
+variable "k8s_service_account_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create Service Account"
+}
+
+variable "k8s_irsa_role_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create IRSA role and annotate service account"
 }
 
 variable "k8s_service_account_name" {
-  type        = string
-  default     = "external-dns"
-  description = "The k8s external-dns service account name"
+  default     = "cluster-autoscaler"
+  description = "The k8s cluster-autoscaler service account name"
 }
 
 variable "settings" {
   type        = map(any)
   default     = {}
-  description = "Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/bitnami/external-dns"
+  description = "Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler"
 }
 
 variable "values" {
   type        = string
   default     = ""
-  description = "Additional values for helm chart. Values will be merged, in order, as Helm does with multiple -f options"
+  description = "Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler"
+}
+
+variable "policy_allowed_zone_ids" {
+  type        = list(string)
+  default     = ["*"]
+  description = "List of the Route53 zone ids for service account IAM role access"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "helm_create_namespace" {
 
 variable "k8s_namespace" {
   type        = string
-  default     = "external-dns"
+  default     = "kube-system"
   description = "The K8s namespace in which the node-problem-detector service account has been created"
 }
 
@@ -80,13 +80,13 @@ variable "k8s_service_account_name" {
 variable "settings" {
   type        = map(any)
   default     = {}
-  description = "Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/external-dns"
+  description = "Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/bitnami/external-dns"
 }
 
 variable "values" {
   type        = string
   default     = ""
-  description = "Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/external-dns"
+  description = "Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/bitnami/external-dns"
 }
 
 variable "policy_allowed_zone_ids" {

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,11 @@ variable "k8s_irsa_role_create" {
   description = "Whether to create IRSA role and annotate service account"
 }
 
+variable "k8s_assume_role_arn" {
+  default     = ""
+  description = "Whether to create and use default role or assume existing role. Useful for hosted zones in another AWS account. Default (empty string) use default role."
+}
+
 variable "k8s_service_account_name" {
   default     = "external-dns"
   description = "The k8s external-dns service account name"

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "helm_chart_name" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "9.10.3"
+  default     = "5.4.4"
   description = "Version of the Helm chart"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -45,13 +45,13 @@ variable "helm_repo_url" {
 variable "helm_create_namespace" {
   type        = bool
   default     = true
-  description = "Create the namespace if it does not yet exist"
+  description = "Whether to create k8s namespace with name defined by `k8s_namespace"
 }
 
 variable "k8s_namespace" {
   type        = string
   default     = "kube-system"
-  description = "The K8s namespace in which the node-problem-detector service account has been created"
+  description = "The K8s namespace in which the external-dns will be installed"
 }
 
 variable "k8s_rbac_create" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "helm_create_namespace" {
 
 variable "k8s_namespace" {
   type        = string
-  default     = "cluster-autoscaler"
+  default     = "external-dns"
   description = "The K8s namespace in which the node-problem-detector service account has been created"
 }
 
@@ -73,20 +73,20 @@ variable "k8s_irsa_role_create" {
 }
 
 variable "k8s_service_account_name" {
-  default     = "cluster-autoscaler"
-  description = "The k8s cluster-autoscaler service account name"
+  default     = "external-dns"
+  description = "The k8s external-dns service account name"
 }
 
 variable "settings" {
   type        = map(any)
   default     = {}
-  description = "Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler"
+  description = "Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/external-dns"
 }
 
 variable "values" {
   type        = string
   default     = ""
-  description = "Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler"
+  description = "Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/external-dns"
 }
 
 variable "policy_allowed_zone_ids" {

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "helm_chart_name" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "4.9.0"
+  default     = "5.4.4"
   description = "Version of the Helm chart"
 }
 
@@ -76,13 +76,14 @@ variable "k8s_service_account_name" {
   description = "The k8s external-dns service account name"
 }
 
-variable "mod_dependency" {
-  default     = null
-  description = "Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable"
-}
-
 variable "settings" {
   type        = map(any)
   default     = {}
   description = "Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/bitnami/external-dns"
+}
+
+variable "values" {
+  type        = string
+  default     = ""
+  description = "Additional values for helm chart. Values will be merged, in order, as Helm does with multiple -f options"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -10,17 +10,9 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 1.0"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 1.10"
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 0.12.0"
     }
   }
 }


### PR DESCRIPTION
Changes:
* Add ability to override or add configuration options in default values 
* Delegate Kubernetes namespace creation to helm provider from Kubernetes provider
* Remove fake dependency variable in favor of terraform built-in module dependency
* Bump default chart version to the 5.4.4

Breaking changes:
* Removes fake dependency variable `mod_dependency` in favor of terraform built-in module dependency injection
Signed-off-by: Ondřej Šmalec <ondrej.smalec@lablabs.io>