### PR TITLE
fix: var.settings boolean error when using argocd

### DIFF
--- a/argo.tf
+++ b/argo.tf
@@ -12,7 +12,7 @@ locals {
       "targetRevision" : var.helm_chart_version
       "helm" : {
         "releaseName" : var.helm_release_name
-        "parameters" : [for k, v in var.settings : tomap({ "forceString" : true, "name" : k, "value" : v })]
+        "parameters" : [for k, v in var.settings : { "forceString" : true, "name" : k, "value" : v }]
         "values" : var.enabled ? data.utils_deep_merge_yaml.values[0].output : ""
       }
     }


### PR DESCRIPTION
# Description

See issue: https://github.com/lablabs/terraform-aws-eks-external-dns/issues/29

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?
Locally modified terraform module in .terraform/modules/ then applied my changes using terraform apply.
