### PR TITLE
feat(policy_document): add var.policy_aws_partition to assemble ARN for multiple partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ No modules.
 | <a name="input_irsa_tags"></a> [irsa\_tags](#input\_irsa\_tags) | IRSA resources tags | `map(string)` | `{}` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The K8s namespace in which the external-dns will be installed | `string` | `"kube-system"` | no |
 | <a name="input_policy_allowed_zone_ids"></a> [policy\_allowed\_zone\_ids](#input\_policy\_allowed\_zone\_ids) | List of the Route53 zone ids for service account IAM role access | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_policy_aws_partition"></a> [policy\_aws\_partition](#input\_policy\_aws\_partition) | AWS partition in which the resources are located. Avaliable values are `aws`, `aws-cn`, `aws-us-gov` | `string` | `"aws"` | no |
 | <a name="input_rbac_create"></a> [rbac\_create](#input\_rbac\_create) | Whether to create and use RBAC resources | `bool` | `true` | no |
 | <a name="input_service_account_create"></a> [service\_account\_create](#input\_service\_account\_create) | Whether to create Service Account | `bool` | `true` | no |
 | <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The k8s external-dns service account name | `string` | `"external-dns"` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -12,7 +12,8 @@ data "aws_iam_policy_document" "this" {
       "route53:ChangeResourceRecordSets",
     ]
     resources = formatlist(
-      "arn:aws:route53:::hostedzone/%s",
+      "arn:%s:route53:::hostedzone/%s",
+      var.policy_aws_partition,
       var.policy_allowed_zone_ids
     )
   }

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,12 @@ variable "policy_allowed_zone_ids" {
   description = "List of the Route53 zone ids for service account IAM role access"
 }
 
+variable "policy_aws_partition" {
+  type        = string
+  default     = "aws"
+  description = "AWS partition in which the resources are located. Avaliable values are `aws`, `aws-cn`, `aws-us-gov`"
+}
+
 variable "irsa_tags" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
# Description

Create variable `policy_aws_partition` to be able to specify the AWS partition in ARNs of the hosted zones used in `aws_iam_policy_document.this`

(reaction to the issue #31 )

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

Tested by running the `terraform plan`
