### PR TITLE
fix(external-dns): remove one function in example/main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ locals {
       } : tomap({})
     }
 
-    extraArgs = one(var.irsa_assume_role_arns) != null ? ["--aws-assume-role=${one(var.irsa_assume_role_arns)}"] : []
+    extraArgs = var.irsa_assume_role_arns != null ? ["--aws-assume-role=${one(var.irsa_assume_role_arns)}"] : []
   })
 
   addon_depends_on = []


### PR DESCRIPTION
# Description

Avoid to use one function when the var.irsa_assume_role_arns is null:

│ Error: Invalid function argument
│ 
│   on .terraform/modules/EXAMPLE/main.tf line 42, in locals:
│   42:     extraArgs = one(var.irsa_assume_role_arns) != null ? ["--aws-assume-role=${one(var.irsa_assume_role_arns)}"] : []
│     ├────────────────
│     │ while calling one(list)
│     │ var.irsa_assume_role_arns is null
│ 
│ Invalid value for "list" parameter: argument must not be null


## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

Directly with a `terraform apply`
